### PR TITLE
Add ProPGF attestations for March and April 2026

### DIFF
--- a/propgf-attestations/2026-03.md
+++ b/propgf-attestations/2026-03.md
@@ -1,0 +1,137 @@
+# ChainSafe ProPGF Attestation — March 2026
+
+This document is an operator-signed attestation that ChainSafe operated the
+listed Filecoin network services during the month of March 2026 (UTC), in
+fulfillment of the ChainSafe ProPGF grant. This file is published
+retroactively in response to the milestone 1 verification feedback dated
+2026-04-27, which noted the absence of dated, operator-signed evidence for
+that month.
+
+## 1. Bootstrap nodes
+
+### Mainnet
+
+The following entries in
+[`lotus/build/bootstrap/mainnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/mainnet.pi)
+were operated by ChainSafe throughout March 2026:
+
+```
+/dns/bootstrap-mainnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWKKkCZbcigsWTEu1cgNetNbZJqeNtysRtFpq7DTqw3eqH
+/dns/bootstrap-mainnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWGnkd9GQKo3apkShQDaq1d6cKJJmsVe6KiQkacUk1T8oZ
+/dns/bootstrap-mainnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWHQRSDFv4FvAjtU32shQ7znz7oRbLBryXzZ9NMK2feyyH
+```
+
+### Calibnet
+
+The following entries in
+[`lotus/build/bootstrap/calibnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/calibnet.pi)
+were operated by ChainSafe throughout March 2026:
+
+```
+/dns/bootstrap-calibnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWABQ5gTDHPWyvhJM7jPhtNwNJruzTEo32Lo4gcS5ABAMm
+/dns/bootstrap-calibnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWS3ZRhMYL67b4bD5XQ6fcpTyVQXnDe8H89LvwrDqaSbiT
+/dns/bootstrap-calibnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWEiBN8jBX8EBoM3M47pVRLRWV812gDRUJhMxgyVkUoR48
+```
+
+### Attribution
+
+All six multiaddrs use the `chainsafe-fil.io` apex domain. ChainSafe is the
+registered operator of `chainsafe-fil.io`, verifiable via public WHOIS and
+via cross-references from `chainsafe.io`.
+
+## 2. Snapshot service
+
+Public endpoint: <https://forest-archive.chainsafe.dev/>
+
+### March 2026 snapshot inventory
+
+The inventory of snapshot files published during March 2026 (file names, R2
+upload timestamps, sizes, and SHA-256 checksum URLs) is reproducible from
+the public listing API:
+
+- <https://forest-archive.chainsafe.dev/list/mainnet/diff?format=json&search=2026-03>
+- <https://forest-archive.chainsafe.dev/list/mainnet/lite?format=json&search=2026-03>
+- <https://forest-archive.chainsafe.dev/list/calibnet/diff?format=json&search=2026-03>
+- <https://forest-archive.chainsafe.dev/list/calibnet/lite?format=json&search=2026-03>
+
+Each snapshot is uploaded alongside a SHA-256 checksum (`<file>.sha256sum`).
+Latest-v2 snapshots are also generated continuously but have a 14-day R2
+retention window.
+
+## 3. Calibnet faucet
+
+Public endpoints:
+
+- <https://faucet.calibnet.chainsafe-fil.io/>
+- <https://forest-explorer.chainsafe.dev/faucet/calibnet>
+
+### Hot wallet
+
+```
+t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa  (Filfox ID: t090)
+```
+
+Explorer: <https://calibration.filfox.info/en/address/t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa>
+
+### March 2026 activity
+
+| Metric                                  | Value          |
+|-----------------------------------------|----------------|
+| Outgoing transfers (March 2026, UTC)    | ~1,387         |
+
+Reproducible from the Filfox transfers API (`/api/v1/address/<addr>/transfers`).
+
+## 4. Calibnet storage miner
+
+Miner ID: **`t0181521`** (created **2026-03-02 01:54:00 UTC**)
+
+| Field                  | Value                                                                        |
+|------------------------|------------------------------------------------------------------------------|
+| Owner/Worker           | `t3q5reevnaozjgnnlvtstxoxsl3cyd754gngljn6msaplriqfoyanvwy2rzx4sx6erqwhnvetvck6icpne4bwa` |
+| Peer ID                | `12D3KooWBRKKo9BbwYDyYJunBaYrxkFRiKchWp361JmTgWBD8eCG`                       |
+
+### March 2026 activity
+
+| Metric                          | Value (approx.) |
+|---------------------------------|-----------------|
+| Blocks won during March 2026    | ~7,400          |
+
+March activity reflects miner ramp-up: the miner was created on March 2 and
+progressively sealed and proved sectors over the remainder of the month,
+producing a partial-month block count that grew toward steady state in
+April.
+
+Explorer: <https://calibration.filfox.info/en/address/t0181521>
+
+## 5. Independent reachability evidence
+
+Independent of internal monitoring, the following public sources establish
+continuous reachability and operation of the listed services in March 2026:
+
+- **Bootstrap nodes:** [ProbeLab](https://probelab.io/filecoin/bootstrappers)
+  probes the ChainSafe bootstrap nodes every 5 minutes and surfaces them
+  publicly under the ChainSafe operator group.
+- **Snapshot service:** Files published in March 2026 are listed by the
+  public API at the URLs in §2. Each file's Cloudflare R2 `uploaded`
+  timestamp falls within the month, independently establishing service
+  operation during the period.
+- **Calibnet miner:** On-chain state records 0 faults across the active
+  sectors throughout the month, itself a proof of continuous WindowPoSt
+  submission for the period after miner creation on 2026-03-02.
+
+## 6. Signature
+
+This file is signed by the introducing git commit, verifiable on GitHub.
+
+```sh
+git log --show-signature -- propgf-attestations/2026-03.md
+```
+
+- **Signing maintainer:** Josh Dougall ([@joshdougall](https://github.com/joshdougall)), ChainSafe Infrastructure
+- **GitHub-verified GPG signing key:** `BA60 5572 E791 78FE 555A  710A A9D0 84B1 DB8D 9E8B`
+- **Signing subkey used:** `21E8 44B3 7FC7 5720 D895  8CD3 875A 3389 54BB 5E63`
+
+---
+
+*Generated for the Filecoin ProPGF grant. Contact:
+[josh@chainsafe.io](mailto:josh@chainsafe.io).*

--- a/propgf-attestations/2026-04.md
+++ b/propgf-attestations/2026-04.md
@@ -1,0 +1,165 @@
+# ChainSafe ProPGF Attestation — April 2026
+
+This document is an operator-signed attestation that ChainSafe operated the
+listed Filecoin network services during the month of April 2026 (UTC), in
+fulfillment of the ChainSafe ProPGF grant.
+
+## 1. Bootstrap nodes
+
+### Mainnet
+
+The following entries in
+[`lotus/build/bootstrap/mainnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/mainnet.pi)
+are operated by ChainSafe:
+
+```
+/dns/bootstrap-mainnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWKKkCZbcigsWTEu1cgNetNbZJqeNtysRtFpq7DTqw3eqH
+/dns/bootstrap-mainnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWGnkd9GQKo3apkShQDaq1d6cKJJmsVe6KiQkacUk1T8oZ
+/dns/bootstrap-mainnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWHQRSDFv4FvAjtU32shQ7znz7oRbLBryXzZ9NMK2feyyH
+```
+
+### Calibnet
+
+The following entries in
+[`lotus/build/bootstrap/calibnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/calibnet.pi)
+are operated by ChainSafe:
+
+```
+/dns/bootstrap-calibnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWABQ5gTDHPWyvhJM7jPhtNwNJruzTEo32Lo4gcS5ABAMm
+/dns/bootstrap-calibnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWS3ZRhMYL67b4bD5XQ6fcpTyVQXnDe8H89LvwrDqaSbiT
+/dns/bootstrap-calibnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWEiBN8jBX8EBoM3M47pVRLRWV812gDRUJhMxgyVkUoR48
+```
+
+### Attribution
+
+All six multiaddrs above use the `chainsafe-fil.io` apex domain. ChainSafe is
+the registered operator of `chainsafe-fil.io`; this is verifiable via:
+
+- Public WHOIS for `chainsafe-fil.io`
+- The `chainsafe.io` corporate site links to the same subdomain pattern
+
+### Reachability
+
+Bootstrap node reachability is independently probed every 5 minutes by
+[ProbeLab](https://probelab.io/filecoin/bootstrappers). All three ChainSafe
+mainnet bootstrap nodes were reachable at the time of this attestation and
+have been continuously listed in the public probe results throughout the
+month.
+
+## 2. Snapshot service
+
+Public endpoint: <https://forest-archive.chainsafe.dev/>
+Long-term R2 bucket: `forest-archive` (Cloudflare R2, public read).
+
+### April 2026 snapshot inventory
+
+The full inventory of snapshot files published during April 2026 (file
+names, R2 upload timestamps, sizes, and SHA-256 checksum URLs) is reproducible
+from the public listing API:
+
+- <https://forest-archive.chainsafe.dev/list/mainnet/diff?format=json&search=2026-04>
+- <https://forest-archive.chainsafe.dev/list/mainnet/lite?format=json&search=2026-04>
+- <https://forest-archive.chainsafe.dev/list/calibnet/diff?format=json&search=2026-04>
+- <https://forest-archive.chainsafe.dev/list/calibnet/lite?format=json&search=2026-04>
+
+Each snapshot is uploaded alongside a SHA-256 checksum (`<file>.sha256sum`)
+accessible via the listing API. Latest-v2 snapshots are also generated
+continuously but have a 14-day R2 retention window.
+
+### Public documentation
+
+- Service description: <https://docs.forest.chainsafe.io/knowledge_base/snapshot_service/>
+- Listed as the official ChainSafe snapshot endpoint on
+  <https://docs.filecoin.io/networks/calibration>
+
+## 3. Calibnet faucet
+
+Public endpoints:
+
+- <https://faucet.calibnet.chainsafe-fil.io/>
+- <https://forest-explorer.chainsafe.dev/faucet/calibnet>
+
+### Hot wallet
+
+Faucet hot wallet (also acts as Notary for DataCap allocations):
+
+```
+t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa  (Filfox ID: t090)
+```
+
+Explorer: <https://calibration.filfox.info/en/address/t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa>
+
+### April 2026 activity
+
+| Metric                                  | Value          |
+|-----------------------------------------|----------------|
+| Outgoing transfers (April 2026, UTC)    | ~505           |
+| Total lifetime transfers                | 886,332        |
+| Total lifetime messages                 | 296,242        |
+
+Outgoing transfer count for April was computed by paging the Filfox transfers
+API (`/api/v1/address/<addr>/transfers`) and filtering by month. The full
+list is reproducible from:
+
+```
+https://calibration.filfox.info/api/v1/address/t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa/transfers?pageSize=100&page=<N>
+```
+
+## 4. Calibnet storage miner
+
+Miner ID: **`t0181521`**
+
+| Field                 | Value                                                                        |
+|-----------------------|------------------------------------------------------------------------------|
+| Owner/Worker          | `t3q5reevnaozjgnnlvtstxoxsl3cyd754gngljn6msaplriqfoyanvwy2rzx4sx6erqwhnvetvck6icpne4bwa` |
+| Peer ID               | `12D3KooWBRKKo9BbwYDyYJunBaYrxkFRiKchWp361JmTgWBD8eCG`                       |
+| Quality-Adjusted Power | 237.81 TiB (rank #3 on calibnet at time of attestation)                     |
+| Active sectors        | 761                                                                          |
+| Faults                | 0                                                                            |
+| Created (height/UTC)  | 2026-03-02 01:54:00 UTC                                                      |
+
+### April 2026 activity
+
+| Metric                          | Value (approx.) |
+|---------------------------------|-----------------|
+| Blocks won during April 2026    | ~34,400         |
+
+Block production figures derived by paginating the Filfox blocks API
+(`https://calibration.filfox.info/api/v1/address/t0181521/blocks`) and
+counting blocks with `timestamp` falling within April 2026 UTC.
+
+Explorer: <https://calibration.filfox.info/en/address/t0181521>
+
+## 5. Independent reachability evidence
+
+Independent of internal monitoring, the following public sources establish
+continuous reachability and operation of the listed services in April 2026:
+
+- **Bootstrap nodes:** [ProbeLab](https://probelab.io/filecoin/bootstrappers)
+  probes the ChainSafe bootstrap nodes every 5 minutes and surfaces them
+  publicly under the ChainSafe operator group.
+- **Snapshot service:** Files published in April 2026 are listed by the
+  public API at the URLs in §2. Each file's Cloudflare R2 `uploaded`
+  timestamp falls within the month, independently establishing service
+  operation during the period.
+- **Calibnet miner:** On-chain state at
+  <https://calibration.filfox.info/en/address/t0181521> records 761 active
+  sectors with **0 faults** in April 2026, which is itself a proof of
+  continuous WindowPoSt submission throughout the month.
+
+## 6. Signature
+
+This file is signed by the introducing git commit, verifiable on GitHub.
+
+```sh
+git log --show-signature -- propgf-attestations/2026-04.md
+```
+
+- **Signing maintainer:** Josh Dougall ([@joshdougall](https://github.com/joshdougall)), ChainSafe Infrastructure
+- **GitHub-verified GPG signing key:** `BA60 5572 E791 78FE 555A  710A A9D0 84B1 DB8D 9E8B`
+- **Signing subkey used:** `21E8 44B3 7FC7 5720 D895  8CD3 875A 3389 54BB 5E63`
+
+---
+
+*Generated for the Filecoin ProPGF grant. Contact:
+[josh@chainsafe.io](mailto:josh@chainsafe.io).*

--- a/propgf-attestations/README.md
+++ b/propgf-attestations/README.md
@@ -19,7 +19,7 @@ maintainer.
 
 ```sh
 # Verify the introducing commit's signature locally
-git log --show-signature -- propgf-attestations/2026-04.md
+git log --show-signature -- propgf-attestations/<YYYY-MM>.md
 ```
 
 Or, on GitHub, look for the "Verified" badge next to the commit on the file

--- a/propgf-attestations/README.md
+++ b/propgf-attestations/README.md
@@ -1,0 +1,33 @@
+# ChainSafe ProPGF Attestations
+
+Monthly operator-signed attestations for the Filecoin ProPGF grant covering
+ChainSafe-operated Filecoin network infrastructure services:
+
+- Mainnet and Calibnet bootstrap nodes
+- Snapshot service (`forest-archive.chainsafe.dev`)
+- Calibnet faucet (`faucet.calibnet.chainsafe-fil.io` and
+  `forest-explorer.chainsafe.dev/faucet/calibnet`)
+- Calibnet storage miner `t0181521`
+
+Each monthly file lists the multiaddrs, wallet addresses, miner IDs, and
+public artifacts that demonstrate ChainSafe operation of those services for
+the month. Each file is introduced by a signed git commit. GitHub records
+the signing key as "Verified" against a key registered to a ChainSafe
+maintainer.
+
+## Verifying an attestation
+
+```sh
+# Verify the introducing commit's signature locally
+git log --show-signature -- propgf-attestations/2026-04.md
+```
+
+Or, on GitHub, look for the "Verified" badge next to the commit on the file
+history.
+
+## ChainSafe-operated DNS
+
+All bootstrap multiaddrs listed in these attestations use the
+`chainsafe-fil.io` domain. Operator identity for the domain is verifiable
+via public WHOIS and via the [`chainsafe.io`](https://chainsafe.io) website
+linking to the same subdomains.


### PR DESCRIPTION
## Summary

Adds operator-signed monthly attestations for the Filecoin ProPGF grant
under `propgf-attestations/`. Each file documents ChainSafe operation of
the funded services for the named month, with links to public APIs that
let any reviewer independently re-derive the evidence.

## Files

- `propgf-attestations/README.md` — index, verification instructions
- `propgf-attestations/2026-03.md` — retroactive attestation in response
  to the milestone 1 verification feedback
- `propgf-attestations/2026-04.md` — attestation for milestone 2

## Verification

The commit is GPG-signed. After merge, the canonical URLs are linked from
the ProPGF milestone forms as deliverable proof:

- https://github.com/ChainSafe/infrastructure/blob/main/propgf-attestations/2026-03.md
- https://github.com/ChainSafe/infrastructure/blob/main/propgf-attestations/2026-04.md

Each file lists only externally verifiable facts: WHOIS-attributable DNS,
public Lotus bootstrap entries, on-chain wallets/miner IDs, and
reproducible JSON listing URLs for the snapshot service.