### PR TITLE
Add ProPGF attestations for May and June 2026

### DIFF
--- a/propgf-attestations/2026-05.md
+++ b/propgf-attestations/2026-05.md
@@ -1,0 +1,164 @@
+# ChainSafe ProPGF Attestation — May 2026
+
+This document is an operator-signed attestation that ChainSafe operated the
+listed Filecoin network services during the month of May 2026 (UTC), in
+fulfillment of the ChainSafe ProPGF grant.
+
+## 1. Bootstrap nodes
+
+### Mainnet
+
+The following entries in
+[`lotus/build/bootstrap/mainnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/mainnet.pi)
+are operated by ChainSafe:
+
+```
+/dns/bootstrap-mainnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWKKkCZbcigsWTEu1cgNetNbZJqeNtysRtFpq7DTqw3eqH
+/dns/bootstrap-mainnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWGnkd9GQKo3apkShQDaq1d6cKJJmsVe6KiQkacUk1T8oZ
+/dns/bootstrap-mainnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWHQRSDFv4FvAjtU32shQ7znz7oRbLBryXzZ9NMK2feyyH
+```
+
+### Calibnet
+
+The following entries in
+[`lotus/build/bootstrap/calibnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/calibnet.pi)
+are operated by ChainSafe:
+
+```
+/dns/bootstrap-calibnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWABQ5gTDHPWyvhJM7jPhtNwNJruzTEo32Lo4gcS5ABAMm
+/dns/bootstrap-calibnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWS3ZRhMYL67b4bD5XQ6fcpTyVQXnDe8H89LvwrDqaSbiT
+/dns/bootstrap-calibnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWEiBN8jBX8EBoM3M47pVRLRWV812gDRUJhMxgyVkUoR48
+```
+
+### Attribution
+
+All six multiaddrs above use the `chainsafe-fil.io` apex domain. ChainSafe is
+the registered operator of `chainsafe-fil.io`; this is verifiable via:
+
+- Public WHOIS for `chainsafe-fil.io`
+- The `chainsafe.io` corporate site links to the same subdomain pattern
+
+### Reachability
+
+Bootstrap node reachability is independently probed every 5 minutes by
+[ProbeLab](https://probelab.io/filecoin/bootstrappers). All three ChainSafe
+mainnet bootstrap nodes were reachable at the time of this attestation and
+have been continuously listed in the public probe results throughout the
+month.
+
+## 2. Snapshot service
+
+Public endpoint: <https://forest-archive.chainsafe.dev/>
+Long-term R2 bucket: `forest-archive` (Cloudflare R2, public read).
+
+### May 2026 snapshot inventory
+
+The full inventory of snapshot files published during May 2026 (file
+names, R2 upload timestamps, sizes, and SHA-256 checksum URLs) is reproducible
+from the public listing API:
+
+- <https://forest-archive.chainsafe.dev/list/mainnet/diff?format=json&search=2026-05>
+- <https://forest-archive.chainsafe.dev/list/mainnet/lite?format=json&search=2026-05>
+- <https://forest-archive.chainsafe.dev/list/calibnet/diff?format=json&search=2026-05>
+- <https://forest-archive.chainsafe.dev/list/calibnet/lite?format=json&search=2026-05>
+
+Each snapshot is uploaded alongside a SHA-256 checksum (`<file>.sha256sum`)
+accessible via the listing API. Latest-v2 snapshots are also generated
+continuously but have a 14-day R2 retention window.
+
+### Public documentation
+
+- Service description: <https://docs.forest.chainsafe.io/knowledge_base/snapshot_service/>
+- Listed as the official ChainSafe snapshot endpoint on
+  <https://docs.filecoin.io/networks/calibration>
+
+## 3. Calibnet faucet
+
+Public endpoints:
+
+- <https://faucet.calibnet.chainsafe-fil.io/>
+- <https://forest-explorer.chainsafe.dev/faucet/calibnet>
+
+### Hot wallet
+
+Faucet hot wallet (also acts as Notary for DataCap allocations):
+
+```
+t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa  (Filfox ID: t090)
+```
+
+Explorer: <https://calibration.filfox.info/en/address/t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa>
+
+### May 2026 activity
+
+| Metric                                  | Value          |
+|-----------------------------------------|----------------|
+| Outgoing transfers (May 2026, UTC)      | ~248           |
+| Total lifetime transfers                | 886,677        |
+| Total lifetime messages                 | 296,358        |
+
+Outgoing transfer count for May was computed by paging the Filfox transfers
+API (`/api/v1/address/<addr>/transfers`) and filtering by month. The full
+list is reproducible from:
+
+```
+https://calibration.filfox.info/api/v1/address/t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa/transfers?pageSize=100&page=<N>
+```
+
+## 4. Calibnet storage miner
+
+Miner ID: **`t0181521`**
+
+| Field                 | Value                                                                        |
+|-----------------------|------------------------------------------------------------------------------|
+| Owner/Worker          | `t3q5reevnaozjgnnlvtstxoxsl3cyd754gngljn6msaplriqfoyanvwy2rzx4sx6erqwhnvetvck6icpne4bwa` |
+| Peer ID               | `12D3KooWBRKKo9BbwYDyYJunBaYrxkFRiKchWp361JmTgWBD8eCG`                       |
+| Quality-Adjusted Power | 237.81 TiB                                                                  |
+| Active sectors        | 761                                                                          |
+| Faults                | 0                                                                            |
+| Created (height/UTC)  | 2026-03-02 01:54:00 UTC                                                      |
+
+### May 2026 activity
+
+| Metric                          | Value (approx.) |
+|---------------------------------|-----------------|
+| Blocks won during May 2026      | ~46,500         |
+
+Block production figures derived by paginating the Filfox blocks API
+(`https://calibration.filfox.info/api/v1/address/t0181521/blocks`) and
+counting blocks with `timestamp` falling within May 2026 UTC.
+
+Explorer: <https://calibration.filfox.info/en/address/t0181521>
+
+## 5. Independent reachability evidence
+
+Independent of internal monitoring, the following public sources establish
+continuous reachability and operation of the listed services in May 2026:
+
+- **Bootstrap nodes:** [ProbeLab](https://probelab.io/filecoin/bootstrappers)
+  probes the ChainSafe bootstrap nodes every 5 minutes and surfaces them
+  publicly under the ChainSafe operator group.
+- **Snapshot service:** Files published in May 2026 are listed by the
+  public API at the URLs in §2. Each file's Cloudflare R2 `uploaded`
+  timestamp falls within the month, independently establishing service
+  operation during the period.
+- **Calibnet miner:** On-chain state at
+  <https://calibration.filfox.info/en/address/t0181521> records 761 active
+  sectors with **0 faults** in May 2026, which is itself a proof of
+  continuous WindowPoSt submission throughout the month.
+
+## 6. Signature
+
+This file is signed by the introducing git commit, verifiable on GitHub.
+
+```sh
+git log --show-signature -- propgf-attestations/2026-05.md
+```
+
+- **Signing maintainer:** Aleksey Zheleznov ([@liveder](https://github.com/liveder)), ChainSafe Infrastructure
+- **GitHub-verified SSH signing key:** `SHA256:0XjJRqcbyVw0gITzHAYGBhU13aH8CbZaB7jis7F5yRA`
+
+---
+
+*Generated for the Filecoin ProPGF grant. Contact:
+[aleksey@chainsafe.io](mailto:aleksey@chainsafe.io).*

--- a/propgf-attestations/2026-06.md
+++ b/propgf-attestations/2026-06.md
@@ -1,0 +1,164 @@
+# ChainSafe ProPGF Attestation — June 2026
+
+This document is an operator-signed attestation that ChainSafe operated the
+listed Filecoin network services during the month of June 2026 (UTC), in
+fulfillment of the ChainSafe ProPGF grant.
+
+## 1. Bootstrap nodes
+
+### Mainnet
+
+The following entries in
+[`lotus/build/bootstrap/mainnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/mainnet.pi)
+are operated by ChainSafe:
+
+```
+/dns/bootstrap-mainnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWKKkCZbcigsWTEu1cgNetNbZJqeNtysRtFpq7DTqw3eqH
+/dns/bootstrap-mainnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWGnkd9GQKo3apkShQDaq1d6cKJJmsVe6KiQkacUk1T8oZ
+/dns/bootstrap-mainnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWHQRSDFv4FvAjtU32shQ7znz7oRbLBryXzZ9NMK2feyyH
+```
+
+### Calibnet
+
+The following entries in
+[`lotus/build/bootstrap/calibnet.pi`](https://github.com/filecoin-project/lotus/blob/master/build/bootstrap/calibnet.pi)
+are operated by ChainSafe:
+
+```
+/dns/bootstrap-calibnet-0.chainsafe-fil.io/tcp/34000/p2p/12D3KooWABQ5gTDHPWyvhJM7jPhtNwNJruzTEo32Lo4gcS5ABAMm
+/dns/bootstrap-calibnet-1.chainsafe-fil.io/tcp/34000/p2p/12D3KooWS3ZRhMYL67b4bD5XQ6fcpTyVQXnDe8H89LvwrDqaSbiT
+/dns/bootstrap-calibnet-2.chainsafe-fil.io/tcp/34000/p2p/12D3KooWEiBN8jBX8EBoM3M47pVRLRWV812gDRUJhMxgyVkUoR48
+```
+
+### Attribution
+
+All six multiaddrs above use the `chainsafe-fil.io` apex domain. ChainSafe is
+the registered operator of `chainsafe-fil.io`; this is verifiable via:
+
+- Public WHOIS for `chainsafe-fil.io`
+- The `chainsafe.io` corporate site links to the same subdomain pattern
+
+### Reachability
+
+Bootstrap node reachability is independently probed every 5 minutes by
+[ProbeLab](https://probelab.io/filecoin/bootstrappers). All three ChainSafe
+mainnet bootstrap nodes were reachable at the time of this attestation and
+have been continuously listed in the public probe results throughout the
+month.
+
+## 2. Snapshot service
+
+Public endpoint: <https://forest-archive.chainsafe.dev/>
+Long-term R2 bucket: `forest-archive` (Cloudflare R2, public read).
+
+### June 2026 snapshot inventory
+
+The full inventory of snapshot files published during June 2026 (file
+names, R2 upload timestamps, sizes, and SHA-256 checksum URLs) is reproducible
+from the public listing API:
+
+- <https://forest-archive.chainsafe.dev/list/mainnet/diff?format=json&search=2026-06>
+- <https://forest-archive.chainsafe.dev/list/mainnet/lite?format=json&search=2026-06>
+- <https://forest-archive.chainsafe.dev/list/calibnet/diff?format=json&search=2026-06>
+- <https://forest-archive.chainsafe.dev/list/calibnet/lite?format=json&search=2026-06>
+
+Each snapshot is uploaded alongside a SHA-256 checksum (`<file>.sha256sum`)
+accessible via the listing API. Latest-v2 snapshots are also generated
+continuously but have a 14-day R2 retention window.
+
+### Public documentation
+
+- Service description: <https://docs.forest.chainsafe.io/knowledge_base/snapshot_service/>
+- Listed as the official ChainSafe snapshot endpoint on
+  <https://docs.filecoin.io/networks/calibration>
+
+## 3. Calibnet faucet
+
+Public endpoints:
+
+- <https://faucet.calibnet.chainsafe-fil.io/>
+- <https://forest-explorer.chainsafe.dev/faucet/calibnet>
+
+### Hot wallet
+
+Faucet hot wallet (also acts as Notary for DataCap allocations):
+
+```
+t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa  (Filfox ID: t090)
+```
+
+Explorer: <https://calibration.filfox.info/en/address/t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa>
+
+### June 2026 activity
+
+| Metric                                  | Value          |
+|-----------------------------------------|----------------|
+| Outgoing transfers (June 2026, UTC)     | ~767           |
+| Total lifetime transfers                | 888,986        |
+| Total lifetime messages                 | 297,132        |
+
+Outgoing transfer count for June was computed by paging the Filfox transfers
+API (`/api/v1/address/<addr>/transfers`) and filtering by month. The full
+list is reproducible from:
+
+```
+https://calibration.filfox.info/api/v1/address/t1lo4ajjyeygqn3lkrw6izwz6aft5chshngs6gjxa/transfers?pageSize=100&page=<N>
+```
+
+## 4. Calibnet storage miner
+
+Miner ID: **`t0181521`**
+
+| Field                 | Value                                                                        |
+|-----------------------|------------------------------------------------------------------------------|
+| Owner/Worker          | `t3q5reevnaozjgnnlvtstxoxsl3cyd754gngljn6msaplriqfoyanvwy2rzx4sx6erqwhnvetvck6icpne4bwa` |
+| Peer ID               | `12D3KooWBRKKo9BbwYDyYJunBaYrxkFRiKchWp361JmTgWBD8eCG`                       |
+| Quality-Adjusted Power | 237.81 TiB                                                                  |
+| Active sectors        | 761                                                                          |
+| Faults                | 0                                                                            |
+| Created (height/UTC)  | 2026-03-02 01:54:00 UTC                                                      |
+
+### June 2026 activity
+
+| Metric                          | Value (approx.) |
+|---------------------------------|-----------------|
+| Blocks won during June 2026     | ~43,200         |
+
+Block production figures derived by paginating the Filfox blocks API
+(`https://calibration.filfox.info/api/v1/address/t0181521/blocks`) and
+counting blocks with `timestamp` falling within June 2026 UTC.
+
+Explorer: <https://calibration.filfox.info/en/address/t0181521>
+
+## 5. Independent reachability evidence
+
+Independent of internal monitoring, the following public sources establish
+continuous reachability and operation of the listed services in June 2026:
+
+- **Bootstrap nodes:** [ProbeLab](https://probelab.io/filecoin/bootstrappers)
+  probes the ChainSafe bootstrap nodes every 5 minutes and surfaces them
+  publicly under the ChainSafe operator group.
+- **Snapshot service:** Files published in June 2026 are listed by the
+  public API at the URLs in §2. Each file's Cloudflare R2 `uploaded`
+  timestamp falls within the month, independently establishing service
+  operation during the period.
+- **Calibnet miner:** On-chain state at
+  <https://calibration.filfox.info/en/address/t0181521> records 761 active
+  sectors with **0 faults** in June 2026, which is itself a proof of
+  continuous WindowPoSt submission throughout the month.
+
+## 6. Signature
+
+This file is signed by the introducing git commit, verifiable on GitHub.
+
+```sh
+git log --show-signature -- propgf-attestations/2026-06.md
+```
+
+- **Signing maintainer:** Aleksey Zheleznov ([@liveder](https://github.com/liveder)), ChainSafe Infrastructure
+- **GitHub-verified SSH signing key:** `SHA256:0XjJRqcbyVw0gITzHAYGBhU13aH8CbZaB7jis7F5yRA`
+
+---
+
+*Generated for the Filecoin ProPGF grant. Contact:
+[aleksey@chainsafe.io](mailto:aleksey@chainsafe.io).*


### PR DESCRIPTION
## Summary

Adds operator-signed monthly attestations for the Filecoin ProPGF grant
under `propgf-attestations/`, continuing the series from #2. Each file
documents ChainSafe operation of the funded services for the named month,
with links to public APIs that let any reviewer independently re-derive the
evidence.

## Files

- `propgf-attestations/2026-05.md` — attestation for May 2026
- `propgf-attestations/2026-06.md` — attestation for June 2026

## Verification

The commit is SSH-signed. After merge, the canonical URLs are linked from
the ProPGF milestone forms as deliverable proof:

- https://github.com/ChainSafe/infrastructure/blob/main/propgf-attestations/2026-05.md
- https://github.com/ChainSafe/infrastructure/blob/main/propgf-attestations/2026-06.md

Each file lists only externally verifiable facts: WHOIS-attributable DNS,
public Lotus bootstrap entries, on-chain wallets/miner IDs, and reproducible
JSON listing URLs for the snapshot service. The faucet transfer counts and
miner block counts were re-derived from the public Filfox API; on-chain
miner state shows 761 active sectors with 0 faults in both months.